### PR TITLE
fix: update gcp configuration and bump console version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ terraform.rc
 
 helm-values
 test/helm-values
+
+# IDE
+.idea/

--- a/templates/setup/console.tf
+++ b/templates/setup/console.tf
@@ -76,7 +76,7 @@ resource "helm_release" "console" {
   namespace        = "plrl-console"
   chart            = "console"
   repository       = "https://pluralsh.github.io/console"
-  version          = "0.1.28"
+  version          = "0.1.38"
   create_namespace = true
   timeout          = 600
   wait             = true

--- a/terraform/clouds/gcp/variables.tf
+++ b/terraform/clouds/gcp/variables.tf
@@ -15,7 +15,7 @@ variable "deletion_protection" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.27.3-gke.100"
+  default = "1.27.10-gke.1055000"
 }
 
 variable "node_pools" {
@@ -62,12 +62,12 @@ variable "subnetwork" {
 
 variable "subnet_cidr" {
   type = string
-  default = "10.0.0.0/17"
+  default = "10.0.16.0/20"
 }
 
 variable "pods_cidr" {
   type = string
-  default = "192.168.0.0/18"
+  default = "10.16.0.0/12"
 }
 
 variable "allocated_range_name" {
@@ -82,7 +82,7 @@ variable "db_size" {
 
 variable "services_cidr" {
   type = string
-  default = "192.168.64.0/18"
+  default = "10.1.0.0/20"
 }
 
 variable "ip_range_pods_name" {


### PR DESCRIPTION
- Console version was outdated and did not match operator version causing operator to crashloop due to usage of non-existing API schema
- CIDR ranges were conflicting with GKE reserved ranges. I have reused ranges from our `plural-artifacts` configuration for GCP
- Bumped GKE version to a working one