### PR TITLE
Add a core-infra stack to set up initial service contexts, and other …

### DIFF
--- a/charts/stateless/.helmignore
+++ b/charts/stateless/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/stateless/Chart.yaml
+++ b/charts/stateless/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: stateless
+description: A Helm chart to deploy a basic stateless application
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/charts/stateless/templates/NOTES.txt
+++ b/charts/stateless/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "stateless.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "stateless.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "stateless.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "stateless.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/stateless/templates/_helpers.tpl
+++ b/charts/stateless/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stateless.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stateless.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "stateless.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "stateless.labels" -}}
+helm.sh/chart: {{ include "stateless.chart" . }}
+{{ include "stateless.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "stateless.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stateless.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stateless.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "stateless.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/stateless/templates/deployment.yaml
+++ b/charts/stateless/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stateless.fullname" . }}
+  labels:
+    {{- include "stateless.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "stateless.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "stateless.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "stateless.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{ if .Values.env }}
+          env:
+          {{ toYaml .Values.env | nindent 12 }}
+          {{ end }}
+          {{ if .Values.envFrom }}
+          envFrom:
+          {{ toYaml .Values.envFrom | nindent 12 }}
+          {{ end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/stateless/templates/hpa.yaml
+++ b/charts/stateless/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stateless.fullname" . }}
+  labels:
+    {{- include "stateless.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stateless.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/stateless/templates/ingress.yaml
+++ b/charts/stateless/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "stateless.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "stateless.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/stateless/templates/service.yaml
+++ b/charts/stateless/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stateless.fullname" . }}
+  labels:
+    {{- include "stateless.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "stateless.selectorLabels" . | nindent 4 }}

--- a/charts/stateless/templates/serviceaccount.yaml
+++ b/charts/stateless/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stateless.serviceAccountName" . }}
+  labels:
+    {{- include "stateless.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/stateless/values.yaml
+++ b/charts/stateless/values.yaml
@@ -1,0 +1,109 @@
+# Default values for stateless.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+env: []
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/setup/notifications.yaml
+++ b/setup/notifications.yaml
@@ -1,0 +1,22 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: NotificationRouter
+metadata:
+  name: deployments
+spec:
+  events:
+  - stack.run
+  - pr.create
+  - pr.close
+  sinks:
+  - name: plural
+    namespace: infra
+---
+apiVersion: deployments.plural.sh/v1alpha1
+kind: NotificationSink
+metadata:
+  name: plural
+spec:
+  type: PLURAL
+  name: plural
+  bindings:
+  - groupName: general

--- a/setup/pr-automation/cluster-creator.yaml
+++ b/setup/pr-automation/cluster-creator.yaml
@@ -18,7 +18,7 @@ spec:
       destination: "bootstrap/clusters.yaml"
       external: false
   scmConnectionRef:
-    name: github  # you'll need to add this ScmConnection manually before this is functional
+    name: plural  # you'll need to add this ScmConnection manually before this is functional
   title: "Adding {{ context.cloud }} cluster: {{ context.name }}"
   message: "Adding {{ context.cloud }} cluster {{ context.name }} and registering it with Plural"
   identifier: [[ .Identifier ]] # REPLACEME with your own repo slug

--- a/setup/pr-automation/scm.yaml
+++ b/setup/pr-automation/scm.yaml
@@ -1,8 +1,8 @@
-# You will need to manually create the github scm connection this refers to
+# You will need to manually create the SCM connection this refers to in the Plural Console UI
 # apiVersion: deployments.plural.sh/v1alpha1
 # kind: ScmConnection
 # metadata:
-#   name: github
+#   name: plural
 # spec:
-#   name: github
+#   name: plural
 #   type: GITHUB

--- a/setup/settings.yaml
+++ b/setup/settings.yaml
@@ -4,6 +4,8 @@ metadata:
   name: global
   namespace: plrl-deploy-operator
 spec:
+  managementRepo: [[ .Identifier ]]
+
   stacks:
     jobSpec:
       namespace: plrl-deploy-operator

--- a/setup/stacks/core-infra.yaml
+++ b/setup/stacks/core-infra.yaml
@@ -1,16 +1,14 @@
 apiVersion: deployments.plural.sh/v1alpha1
 kind: InfrastructureStack
 metadata:
-  name: cluster-{{ context.name }}
+  name: core-infra
 spec:
-  name: cluster-{{ context.name }}
+  name: core-infra
   detach: false
   type: TERRAFORM
   approval: true
   manageState: true
   actor: console@plural.sh
-  configuration:
-    version: '1.8'
   repositoryRef:
     name: infra
     namespace: infra
@@ -18,9 +16,8 @@ spec:
     name: mgmt
     namespace: infra
   variables:
-    cluster: {{ context.name }}
-    fleet: {{ context.fleet }}
-    tier: {{ context.tier }}
+    region: [[ .Region ]]
+    cluster_name: [[ .Cluster ]]
   git:
-    ref: {{ context.branch | default "main" }}
-    folder: terraform/modules/clusters/{{ context.cloud }}
+    ref: main
+    folder: terraform/core-infra

--- a/setup/stacks/mgmt.yaml
+++ b/setup/stacks/mgmt.yaml
@@ -15,6 +15,8 @@ spec:
   clusterRef:
     name: mgmt
     namespace: infra
+  variables:
+    use_cli: false
   git:
     ref: main
     folder: terraform/mgmt

--- a/setup/stacks/mgmt.yaml
+++ b/setup/stacks/mgmt.yaml
@@ -1,0 +1,20 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: InfrastructureStack
+metadata:
+  name: mgmt
+spec:
+  name: mgmt
+  detach: false
+  type: TERRAFORM
+  approval: true
+  manageState: false
+  actor: console@plural.sh
+  repositoryRef:
+    name: infra
+    namespace: infra
+  clusterRef:
+    name: mgmt
+    namespace: infra
+  git:
+    ref: main
+    folder: terraform/mgmt

--- a/templates/providers/bootstrap/aws.tf
+++ b/templates/providers/bootstrap/aws.tf
@@ -42,13 +42,17 @@ provider "aws" {
 data "aws_eks_cluster" "cluster" {
   name = module.mgmt.cluster.cluster_name
 
+  # BEGIN REMOVE
   depends_on = [ module.mgmt.cluster ]
+  # END REMOVE
 }
 
 data "aws_eks_cluster_auth" "cluster" {
   name = module.mgmt.cluster.cluster_name
 
+  # BEGIN REMOVE
   depends_on = [ module.mgmt.cluster ]
+  # END REMOVE
 }
 
 provider "kubernetes" {
@@ -66,7 +70,7 @@ provider "helm" {
 }
 
 provider "plural" {
-  use_cli = true # If you want to have a Plural stack manage your console, comment this out and use the `actor` field
+  use_cli = var.use_cli # If you want to have a Plural stack manage your console, comment this out and use the `actor` field
 }
 
 ## useful outputs dumped here, can be moved to a separate file post-generate
@@ -76,4 +80,9 @@ output "cloudwatch_iam_arn" {
 
 output "vpc_id" {
   value = module.mgmt.vpc.vpc_id
+}
+
+variable "use_cli" {
+  type = bool
+  default = true
 }

--- a/templates/providers/bootstrap/azure.tf
+++ b/templates/providers/bootstrap/azure.tf
@@ -69,5 +69,10 @@ provider "helm" {
 }
 
 provider "plural" {
-  use_cli = true # If you want to have a Plural stack manage your console, comment this out and use the `actor` field
+  use_cli = var.use_cli # If you want to have a Plural stack manage your console, comment this out and use the `actor` field
+}
+
+variable "use_cli" {
+  type = bool
+  default = true
 }

--- a/templates/providers/bootstrap/gcp.tf
+++ b/templates/providers/bootstrap/gcp.tf
@@ -44,5 +44,10 @@ provider "helm" {
 }
 
 provider "plural" {
-  use_cli = true # If you want to have a Plural stack manage your console, comment this out and use the `actor` field
+  use_cli = var.use_cli # If you want to have a Plural stack manage your console, comment this out and use the `actor` field
+}
+
+variable "use_cli" {
+  type = bool
+  default = true
 }

--- a/templates/providers/bootstrap/linode.tf
+++ b/templates/providers/bootstrap/linode.tf
@@ -52,5 +52,10 @@ provider "helm" {
 }
 
 provider "plural" {
-  use_cli = true # If you want to have a Plural stack manage your console, comment this out and use the `actor` field
+  use_cli = var.use_cli # If you want to have a Plural stack manage your console, comment this out and use the `actor` field
+}
+
+variable "use_cli" {
+  type = bool
+  default = true
 }

--- a/terraform/clouds/aws/variables.tf
+++ b/terraform/clouds/aws/variables.tf
@@ -107,3 +107,8 @@ variable "monitoring_role" {
   type = string
   default = ""
 }
+
+variable "additional_kms_administrators" {
+  type = list(string)
+  default = [ ]
+}

--- a/terraform/core-infra/aws/README.md
+++ b/terraform/core-infra/aws/README.md
@@ -1,0 +1,4 @@
+# this can be used for provisioning any base infrastructure for your environment, a couple of common usecases:
+#   * setting up multi-cluster networks
+#   * setting up dns zones, subdomains, etc
+#   * configuring Cloud IAM throughout your environment 

--- a/terraform/core-infra/aws/context.tf
+++ b/terraform/core-infra/aws/context.tf
@@ -1,0 +1,17 @@
+data "aws_eks_cluster" "mgmt" {
+  name = var.cluster_name
+}
+
+data "aws_vpc" "mgmt" {
+  id = one(data.aws_eks_cluster.mgmt.vpc_config).vpc_id
+}
+
+resource "plural_service_context" "mgmt" {
+    name = "plrl/clusters/mgmt"
+    configuration = {
+        cluster_name = var.cluster_name
+        vpc_id       = one(data.aws_eks_cluster.mgmt.vpc_config).vpc_id
+        subnet_ids   = one(data.aws_eks_cluster.mgmt.vpc_config).subnet_ids
+        vpc_cidr     = data.aws_vpc.mgmt.cidr_block
+    }
+}

--- a/terraform/core-infra/aws/context.tf
+++ b/terraform/core-infra/aws/context.tf
@@ -8,10 +8,10 @@ data "aws_vpc" "mgmt" {
 
 resource "plural_service_context" "mgmt" {
     name = "plrl/clusters/mgmt"
-    configuration = {
+    configuration = jsonencode({
         cluster_name = var.cluster_name
         vpc_id       = one(data.aws_eks_cluster.mgmt.vpc_config).vpc_id
         subnet_ids   = one(data.aws_eks_cluster.mgmt.vpc_config).subnet_ids
         vpc_cidr     = data.aws_vpc.mgmt.cidr_block
-    }
+    })
 }

--- a/terraform/core-infra/aws/variables.tf
+++ b/terraform/core-infra/aws/variables.tf
@@ -1,0 +1,8 @@
+variable "region" {
+  type = string
+  default = "us-east-2"
+}
+
+variable "cluster_name" {
+    type = string
+}

--- a/terraform/core-infra/aws/versions.tf
+++ b/terraform/core-infra/aws/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+
+    plural = {
+      source = "pluralsh/plural"
+      version = ">= 0.2.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+
+provider "plural" { }

--- a/terraform/core-infra/azure/README.md
+++ b/terraform/core-infra/azure/README.md
@@ -1,0 +1,4 @@
+# this can be used for provisioning any base infrastructure for your environment, a couple of common usecases:
+#   * setting up multi-cluster networks
+#   * setting up dns zones, subdomains, etc
+#   * configuring Cloud IAM throughout your environment 

--- a/terraform/core-infra/azure/variables.tf
+++ b/terraform/core-infra/azure/variables.tf
@@ -1,0 +1,8 @@
+variable "region" {
+  type = string
+  default = "us-east-2"
+}
+
+variable "cluster_name" {
+  type = string
+}

--- a/terraform/core-infra/azure/versions.tf
+++ b/terraform/core-infra/azure/versions.tf
@@ -2,27 +2,23 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    google = {
-      source  = "hashicorp/google"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.10"
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.51.0, < 4.0"
     }
     plural = {
       source = "pluralsh/plural"
       version = ">= 0.2.9"
     }
-    local = {
-        source = "hashicorp/local"
-    }
   }
 }
 
-provider "google" {
-  region = var.region
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
-
-data "google_client_config" "default" {}
 
 provider "plural" { }

--- a/terraform/core-infra/azure/versions.tf
+++ b/terraform/core-infra/azure/versions.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+    plural = {
+      source = "pluralsh/plural"
+      version = ">= 0.2.9"
+    }
+    local = {
+        source = "hashicorp/local"
+    }
+  }
+}
+
+provider "google" {
+  region = var.region
+}
+
+data "google_client_config" "default" {}
+
+provider "plural" { }

--- a/terraform/core-infra/gcp/README.md
+++ b/terraform/core-infra/gcp/README.md
@@ -1,0 +1,4 @@
+# this can be used for provisioning any base infrastructure for your environment, a couple of common usecases:
+#   * setting up multi-cluster networks
+#   * setting up dns zones, subdomains, etc
+#   * configuring Cloud IAM throughout your environment 

--- a/terraform/core-infra/gcp/context.tf
+++ b/terraform/core-infra/gcp/context.tf
@@ -1,0 +1,22 @@
+data "google_container_cluster" "mgmt" {
+  name = var.cluster_name
+  location = var.region
+}
+
+data "google_compute_network" "network" {
+  name = data.google_container_cluster.mgmt.network
+}
+
+data "google_compute_subnetwork" "subnetwork" {
+  name = data.google_container_cluster.mgmt.subnetwork
+}
+
+resource "plural_service_context" "mgmt" {
+    name = "plrl/clusters/mgmt"
+    configuration = {
+        cluster_name = var.cluster_name
+        network      = data.google_container_cluster.mgmt.network
+        subnetwork   = data.google_container_cluster.mgmt.subnetwork
+        cidr         = data.google_compute_subnetwork.ip_cidr_range
+    }
+}

--- a/terraform/core-infra/gcp/context.tf
+++ b/terraform/core-infra/gcp/context.tf
@@ -13,10 +13,10 @@ data "google_compute_subnetwork" "subnetwork" {
 
 resource "plural_service_context" "mgmt" {
     name = "plrl/clusters/mgmt"
-    configuration = {
+    configuration = jsonencode({
         cluster_name = var.cluster_name
         network      = data.google_container_cluster.mgmt.network
         subnetwork   = data.google_container_cluster.mgmt.subnetwork
         cidr         = data.google_compute_subnetwork.ip_cidr_range
-    }
+    })
 }

--- a/terraform/core-infra/gcp/variables.tf
+++ b/terraform/core-infra/gcp/variables.tf
@@ -1,0 +1,8 @@
+variable "region" {
+  type = string
+  default = "us-east-2"
+}
+
+variable "cluster_name" {
+    type = string
+}

--- a/terraform/core-infra/gcp/versions.tf
+++ b/terraform/core-infra/gcp/versions.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+    plural = {
+      source = "pluralsh/plural"
+      version = ">= 0.2.9"
+    }
+    local = {
+        source = "hashicorp/local"
+    }
+  }
+}
+
+provider "google" {
+  region = var.region
+}
+
+data "google_client_config" "default" {}
+
+provider "plural" { }

--- a/terraform/core-infra/gcp/versions.tf
+++ b/terraform/core-infra/gcp/versions.tf
@@ -5,16 +5,9 @@ terraform {
     google = {
       source  = "hashicorp/google"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.10"
-    }
     plural = {
       source = "pluralsh/plural"
       version = ">= 0.2.9"
-    }
-    local = {
-        source = "hashicorp/local"
     }
   }
 }

--- a/terraform/modules/clusters/aws/context.tf
+++ b/terraform/modules/clusters/aws/context.tf
@@ -1,0 +1,11 @@
+resource "plural_service_context" "mgmt" {
+    name = "plrl/clusters/${var.cluster_name}"
+    configuration = {
+        cluster_name    = var.cluster_name
+        vpc_id          = module.vpc.vpc_id
+        subnet_ids      = concat(module.vpc.public_subnets, module.vpc.private_subnets)
+        private_subnets = module.vpc.private_subnets
+        public_subnets  = module.vpc.public_subnets
+        vpc_cidr        = var.vpc_cidr
+    }
+}

--- a/terraform/modules/clusters/gcp/context.tf
+++ b/terraform/modules/clusters/gcp/context.tf
@@ -1,0 +1,10 @@
+resource "plural_service_context" "mgmt" {
+    name = "plrl/clusters/${var.cluster_name}"
+
+    configuration = {
+        cluster_name = var.cluster_name
+        network      = module.gcp-network.network_name
+        subnetwork   = module.gcp-network.subnets_names[0]
+        cidr         = var.subnet_cidr
+    }
+}


### PR DESCRIPTION
…stuff

This is generally nice to have, but also will ensure the management console has a service context, alongside the ones we put on the other clusters