### PR TITLE
feat: Use k8s v1.30

### DIFF
--- a/templates/providers/bootstrap/azure.tf
+++ b/templates/providers/bootstrap/azure.tf
@@ -51,6 +51,9 @@ provider "azurerm" {
       prevent_deletion_if_contains_resources = false
     }
   }
+
+  subscription_id = "{{ .Context.SubscriptionId }}"
+  tenant_id = "{{ .Context.TenantId }}"
 }
 
 provider "kubernetes" {

--- a/templates/providers/bootstrap/azure.tf
+++ b/templates/providers/bootstrap/azure.tf
@@ -3,6 +3,7 @@ terraform {
 
   backend "azurerm" {
     storage_account_name = "{{ .Context.StorageAccount }}"
+    subscription_id = "{{ .Context.SubscriptionId }}"
     resource_group_name = "{{ .Project }}"
     container_name = "{{ .Bucket }}"
     key = "{{ .Cluster }}/bootstrap/terraform.tfstate"

--- a/terraform/clouds/aws/runtime.tf
+++ b/terraform/clouds/aws/runtime.tf
@@ -9,13 +9,14 @@ module "eks_blueprints_addons" {
 
   eks_addons = {
     aws-ebs-csi-driver = {
-      most_recent = true
+      most_recent              = true
       service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
       configuration_values = jsonencode({
         defaultStorageClass = {
           enabled = true
         }
       })
+    }
     coredns = {
       most_recent = true
     }

--- a/terraform/clouds/aws/runtime.tf
+++ b/terraform/clouds/aws/runtime.tf
@@ -11,7 +11,11 @@ module "eks_blueprints_addons" {
     aws-ebs-csi-driver = {
       most_recent = true
       service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
-    }
+      configuration_values = jsonencode({
+        defaultStorageClass = {
+          enabled = true
+        }
+      })
     coredns = {
       most_recent = true
     }

--- a/terraform/clouds/aws/variables.tf
+++ b/terraform/clouds/aws/variables.tf
@@ -25,7 +25,7 @@ variable "create_db" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.29"
+  default = "1.30"
 }
 
 variable "public" {

--- a/terraform/clouds/azure/variables.tf
+++ b/terraform/clouds/azure/variables.tf
@@ -15,7 +15,7 @@ variable "create_db" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.29.7"
+  default = "1.30.9"
 }
 
 variable "create_resource_group" {

--- a/terraform/clouds/gcp/network.tf
+++ b/terraform/clouds/gcp/network.tf
@@ -3,7 +3,7 @@ module "gcp-network" {
   version = ">= 7.5"
 
   project_id   = var.project_id
-  network_name = var.network
+  network_name = "${var.cluster_name}-${var.network}"
 
   subnets = [
     {

--- a/terraform/clouds/gcp/variables.tf
+++ b/terraform/clouds/gcp/variables.tf
@@ -15,7 +15,7 @@ variable "deletion_protection" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.29"
+  default = "1.30"
 }
 
 variable "node_pools" {

--- a/terraform/modules/clusters/aws/addons.tf
+++ b/terraform/modules/clusters/aws/addons.tf
@@ -11,6 +11,11 @@ module "addons" {
     aws-ebs-csi-driver = {
       most_recent = true
       service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
+      configuration_values = jsonencode({
+        defaultStorageClass = {
+          enabled = true
+        }
+      })
     }
     coredns = {
       most_recent = true

--- a/terraform/modules/clusters/aws/variables.tf
+++ b/terraform/modules/clusters/aws/variables.tf
@@ -23,7 +23,7 @@ variable "public" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.29"
+  default = "1.30"
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
Updated K8s version to v1.30:
- AWS - the only issue was the storage class not being marked as default anymore, it's fixed.
- Azure - there was issue with initialising the backend (subscription ID was empty when there were no environment variables set), it's fixed. There is also a restriction that subscription may not be allowed to provision database with HA in all locations.
- GCP - parametrized network name to allow creating multiple clusters in the same project.