### PR TITLE
fix: Fix `mgmt` stack on Azure

### DIFF
--- a/setup/stacks/mgmt.yaml
+++ b/setup/stacks/mgmt.yaml
@@ -17,6 +17,26 @@ spec:
     namespace: infra
   variables:
     use_cli: false
+  [[ if eq .Provider "azure" ]]
+  environment:
+    - name: ARM_USE_OIDC
+      value: "true"
+    - name: ARM_USE_CLI
+      value: "false"
+    - name: ARM_OIDC_TOKEN_FILE_PATH
+      value: "/var/run/secrets/azure/tokens/azure-identity-token"
+    - name: ARM_CLIENT_ID
+      value: [[ .StacksIdentity ]]
+    - name: ARM_TENANT_ID
+      value: [[ .Context.TenantId ]]
+    - name: ARM_SUBSCRIPTION_ID
+      value: [[ .Context.SubscriptionId ]]
+  jobSpec:
+    namespace: plrl-deploy-operator
+    labels:
+      azure.workload.identity/use: "true"
+    serviceAccount: "stacks"
+  [[ end ]]
   git:
     ref: main
     folder: terraform/mgmt

--- a/setup/stacks/mgmt.yaml
+++ b/setup/stacks/mgmt.yaml
@@ -26,7 +26,7 @@ spec:
     - name: ARM_OIDC_TOKEN_FILE_PATH
       value: "/var/run/secrets/azure/tokens/azure-identity-token"
     - name: ARM_CLIENT_ID
-      value: [[ .StacksIdentity ]]
+      value: {{ .StacksIdentity }}
     - name: ARM_TENANT_ID
       value: [[ .Context.TenantId ]]
     - name: ARM_SUBSCRIPTION_ID


### PR DESCRIPTION
I have tested it by doing full `plural up`. First run of `mgmt` stack failed as post setup resource cleanup from `core-infra` did not pass yet. After it finished the next `mgmt` stack run was successful.

Requires https://github.com/pluralsh/plural-cli/pull/618.