### PR TITLE
Add secrets mounting in stateless helm chart

### DIFF
--- a/charts/stateless/templates/deployment.yaml
+++ b/charts/stateless/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+          - secretRef:  
+              name: {{ include "stateless.fullname" . }}-secret-env
           {{ if .Values.env }}
           env:
           {{ toYaml .Values.env | nindent 12 }}

--- a/charts/stateless/templates/secret.yaml
+++ b/charts/stateless/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stateless.fullname" . }}-secret-env
+  labels:
+    {{- include "stateless.labels" . | nindent 4 }}
+stringData:
+  APP_IMAGE: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  APP_VERSION: "{{ .Chart.AppVersion }}"
+{{ if .Values.secrets}}
+{{ range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | quote }}
+{{ end }}
+{{ end }}

--- a/charts/stateless/values.yaml
+++ b/charts/stateless/values.yaml
@@ -10,7 +10,11 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# env is a list of kubernetes container environment variables to be added to the pod
 env: []
+
+# secrets are a key-value map of secrets to be mounted into the pod
+secrets: ~
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/stateless/values.yaml.liquid
+++ b/charts/stateless/values.yaml.liquid
@@ -1,0 +1,5 @@
+dummy: 'true'
+{% for secret in configuration %}
+secrets:
+  {{ secret[0] }}: "{{ secret[1] }}"
+{% endfor %}


### PR DESCRIPTION
This will allow users to auto-mount plural secrets from the ui into services