### PR TITLE
fix(gcp): resolve core-infra stack issues and standardize resource naming

### DIFF
--- a/templates/setup/console.tf
+++ b/templates/setup/console.tf
@@ -76,7 +76,7 @@ resource "helm_release" "console" {
   namespace        = "plrl-console"
   chart            = "console"
   repository       = "https://pluralsh.github.io/console"
-  version          = "0.3.79"
+  version          = "0.3.84"
   create_namespace = true
   timeout          = 600
   wait             = true

--- a/templates/setup/providers/gcp.tf
+++ b/templates/setup/providers/gcp.tf
@@ -9,7 +9,7 @@ variable "network" {
 variable "subnetwork" {
   type = string
   description = "The subnetwork created to host the cluster in"
-  default     = "plural"
+  default     = "plural-core"
 }
 
 module "mgmt" {

--- a/templates/setup/providers/gcp.tf
+++ b/templates/setup/providers/gcp.tf
@@ -3,13 +3,13 @@
 variable "network" {
   type = string
   description = "The VPC network created to host the cluster in"
-  default     = "plural-network"
+  default     = "plural-core"
 }
 
 variable "subnetwork" {
   type = string
   description = "The subnetwork created to host the cluster in"
-  default     = "plural-subnet"
+  default     = "plural"
 }
 
 module "mgmt" {

--- a/terraform/clouds/gcp/locals.tf
+++ b/terraform/clouds/gcp/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  db_name = var.db_name == "" ? "${var.cluster_name}-plural-db" : var.db_name
+  db_name    = var.db_name == "" ? "${var.cluster_name}-plural-db" : var.db_name
   range_name = var.allocated_range_name == "" ? "${var.cluster_name}-managed-services" : var.allocated_range_name
   db_url = format("postgresql://console:%s@%s:5432/console", random_password.password.result, try(module.pg[0].private_ip_address, ""))
-  # db_created = var.create_db ? module.pg.0.google_sql_user.default[0] : {}
+  network_name = format("%s-%s", var.cluster_name, var.network)
 }

--- a/terraform/clouds/gcp/locals.tf
+++ b/terraform/clouds/gcp/locals.tf
@@ -3,4 +3,5 @@ locals {
   range_name = var.allocated_range_name == "" ? "${var.cluster_name}-managed-services" : var.allocated_range_name
   db_url = format("postgresql://console:%s@%s:5432/console", random_password.password.result, try(module.pg[0].private_ip_address, ""))
   network_name = format("%s-%s", var.cluster_name, var.network)
+  subnetwork_name = format("%s-%s", var.cluster_name, var.subnetwork)
 }

--- a/terraform/clouds/gcp/network.tf
+++ b/terraform/clouds/gcp/network.tf
@@ -3,7 +3,7 @@ module "gcp-network" {
   version = ">= 7.5"
 
   project_id   = var.project_id
-  network_name = "${var.cluster_name}-${var.network}"
+  network_name = local.network_name
 
   subnets = [
     {
@@ -34,7 +34,7 @@ resource "google_compute_global_address" "private_ip_alloc" {
   address_type  = "INTERNAL"
   prefix_length = 16
   network       = module.gcp-network.network_id
-  project       = var.project_id 
+  project       = var.project_id
 }
 
 

--- a/terraform/clouds/gcp/network.tf
+++ b/terraform/clouds/gcp/network.tf
@@ -7,7 +7,7 @@ module "gcp-network" {
 
   subnets = [
     {
-      subnet_name   = var.subnetwork
+      subnet_name   = local.subnetwork_name
       subnet_ip     = var.subnet_cidr
       subnet_region = var.region
     },

--- a/terraform/clouds/gcp/postgres.tf
+++ b/terraform/clouds/gcp/postgres.tf
@@ -8,8 +8,8 @@ resource "random_password" "password" {
 
 module "pg" {
   count = var.create_db ? 1 : 0
-  source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version = "~> 22.0"
+  source  = "terraform-google-modules/sql-db/google//modules/postgresql"
+  version = "~> 25.2"
 
   name                 = local.db_name
   random_instance_name = false

--- a/terraform/clouds/gcp/variables.tf
+++ b/terraform/clouds/gcp/variables.tf
@@ -1,41 +1,41 @@
 variable "cluster_name" {
-  type = string
+  type    = string
   default = "plural"
 }
 
 variable "create_db" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "deletion_protection" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "kubernetes_version" {
-  type = string
+  type    = string
   default = "1.30"
 }
 
 variable "node_pools" {
   type = list(any)
-  default = [ {name = "default-node-pool"} ]
+  default = [{ name = "default-node-pool" }]
 }
 
 variable "node_pools_taints" {
   type = map(list(object({ key = string, value = string, effect = string })))
-  default = { "all": [], "default-node-pool": [] }
+  default = { "all" : [], "default-node-pool" : [] }
 }
 
 variable "node_pools_labels" {
   type = map(map(string))
-  default = { "all": {}, "default-node-pool": {} }
+  default = { "all" : {}, "default-node-pool" : {} }
 }
 
 variable "node_pools_tags" {
   type = map(list(string))
-  default = { "all": [], "default-node-pool": [] }
+  default = { "all" : [], "default-node-pool" : [] }
 }
 
 variable "project_id" {
@@ -43,61 +43,61 @@ variable "project_id" {
 }
 
 variable "region" {
-  type = string
+  type        = string
   description = "The region to host the cluster in"
   default     = "us-central1"
 }
 
 variable "network" {
-  type = string
+  type        = string
   description = "The VPC network created to host the cluster in"
-  default     = "plural-network"
+  default     = "plural-core"
 }
 
 variable "subnetwork" {
-  type = string
+  type        = string
   description = "The subnetwork created to host the cluster in"
-  default     = "plural-subnet"
+  default     = "plural"
 }
 
 variable "subnet_cidr" {
-  type = string
+  type    = string
   default = "10.0.16.0/20"
 }
 
 variable "pods_cidr" {
-  type = string
+  type    = string
   default = "10.16.0.0/12"
 }
 
 variable "allocated_range_name" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "db_size" {
-  type = string
+  type    = string
   default = "db-custom-4-8192"
 }
 
 variable "services_cidr" {
-  type = string
+  type    = string
   default = "10.1.0.0/20"
 }
 
 variable "ip_range_pods_name" {
-  type = string
+  type        = string
   description = "The secondary ip range to use for pods"
-  default     = "ip-range-pods"
+  default     = "plural-pods"
 }
 
 variable "ip_range_services_name" {
-  type = string
+  type        = string
   description = "The secondary ip range to use for services"
-  default     = "ip-range-svc"
+  default     = "plural-services"
 }
 
 variable "db_name" {
-  type = string
+  type    = string
   default = ""
 }

--- a/terraform/clouds/gcp/variables.tf
+++ b/terraform/clouds/gcp/variables.tf
@@ -57,7 +57,7 @@ variable "network" {
 variable "subnetwork" {
   type        = string
   description = "The subnetwork created to host the cluster in"
-  default     = "plural"
+  default     = "plural-core"
 }
 
 variable "subnet_cidr" {

--- a/terraform/core-infra/gcp/context.tf
+++ b/terraform/core-infra/gcp/context.tf
@@ -1,5 +1,5 @@
 data "google_container_cluster" "mgmt" {
-  name = var.cluster_name
+  name     = var.cluster_name
   location = var.region
 }
 
@@ -17,12 +17,12 @@ data "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "plural_service_context" "mgmt" {
-    name = "plrl/clusters/mgmt"
-    configuration = jsonencode({
-        region       = var.region
-        cluster_name = var.cluster_name
-        network      = data.google_container_cluster.mgmt.network
-        subnetwork   = data.google_container_cluster.mgmt.subnetwork
-        cidr         = data.google_compute_subnetwork.subnetwork.ip_cidr_range
-    })
+  name = "plrl/clusters/mgmt"
+  configuration = jsonencode({
+    region       = var.region
+    cluster_name = var.cluster_name
+    network      = data.google_container_cluster.mgmt.network
+    subnetwork   = data.google_container_cluster.mgmt.subnetwork
+    cidr         = data.google_compute_subnetwork.subnetwork.ip_cidr_range
+  })
 }

--- a/terraform/core-infra/gcp/context.tf
+++ b/terraform/core-infra/gcp/context.tf
@@ -18,6 +18,6 @@ resource "plural_service_context" "mgmt" {
         cluster_name = var.cluster_name
         network      = data.google_container_cluster.mgmt.network
         subnetwork   = data.google_container_cluster.mgmt.subnetwork
-        cidr         = data.google_compute_subnetwork.ip_cidr_range
+        cidr         = data.google_compute_subnetwork.subnetwork.ip_cidr_range
     })
 }

--- a/terraform/core-infra/gcp/context.tf
+++ b/terraform/core-infra/gcp/context.tf
@@ -3,12 +3,17 @@ data "google_container_cluster" "mgmt" {
   location = var.region
 }
 
+locals {
+  short_network_name = basename(data.google_container_cluster.mgmt.network)
+  short_subnetwork_name = basename(data.google_container_cluster.mgmt.subnetwork)
+}
+
 data "google_compute_network" "network" {
-  name = data.google_container_cluster.mgmt.network
+  name = local.short_network_name
 }
 
 data "google_compute_subnetwork" "subnetwork" {
-  name = data.google_container_cluster.mgmt.subnetwork
+  name = local.short_subnetwork_name
 }
 
 resource "plural_service_context" "mgmt" {

--- a/terraform/core-infra/gcp/locals.tf
+++ b/terraform/core-infra/gcp/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  network_name = format("%s-%s", var.cluster_name)
-}

--- a/terraform/core-infra/gcp/locals.tf
+++ b/terraform/core-infra/gcp/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  network_name = format("%s-%s", var.cluster_name)
+}

--- a/terraform/core-infra/gcp/network.tf
+++ b/terraform/core-infra/gcp/network.tf
@@ -4,8 +4,8 @@ module "network_dev" {
   source  = "terraform-google-modules/network/google"
   version = ">= 7.5"
 
-  project_id   = data.google_project.current.number
-  network_name = "plural-dev"
+  project_id = data.google_project.current.number
+  network_name = format("%s-plural-dev", var.cluster_name)
 
   subnets = [
     {
@@ -33,8 +33,8 @@ module "network_prod" {
   source  = "terraform-google-modules/network/google"
   version = ">= 7.5"
 
-  project_id   = data.google_project.current.number
-  network_name = "plural-prod"
+  project_id = data.google_project.current.number
+  network_name = format("%s-plural-prod", var.cluster_name)
 
   subnets = [
     {
@@ -59,23 +59,23 @@ module "network_prod" {
 }
 
 resource "plural_service_context" "dev-vpc" {
-    name = "plrl/vpc/dev"
+  name = "plrl/vpc/dev"
 
-    configuration = jsonencode({
-        network                = module.network_dev.network_name
-        subnetwork             = module.network_dev.subnets_names[0]
-        ip_range_pods          = var.ip_range_pods_name
-        ip_range_services      = var.ip_range_services_name
-    })
+  configuration = jsonencode({
+    network           = module.network_dev.network_name
+    subnetwork        = module.network_dev.subnets_names[0]
+    ip_range_pods     = var.ip_range_pods_name
+    ip_range_services = var.ip_range_services_name
+  })
 }
 
 resource "plural_service_context" "prod-vpc" {
-    name = "plrl/vpc/prod"
+  name = "plrl/vpc/prod"
 
-    configuration = jsonencode({
-        network                = module.network_prod.network_name
-        subnetwork             = module.network_prod.subnets_names[0]
-        ip_range_pods          = var.ip_range_pods_name
-        ip_range_services      = var.ip_range_services_name
-    })
+  configuration = jsonencode({
+    network           = module.network_prod.network_name
+    subnetwork        = module.network_prod.subnets_names[0]
+    ip_range_pods     = var.ip_range_pods_name
+    ip_range_services = var.ip_range_services_name
+  })
 }

--- a/terraform/core-infra/gcp/network.tf
+++ b/terraform/core-infra/gcp/network.tf
@@ -9,7 +9,7 @@ module "network_dev" {
 
   subnets = [
     {
-      subnet_name   = "plural-dev-subnet"
+      subnet_name = format("%s-plural-dev", var.cluster_name)
       subnet_ip     = var.subnet_cidr
       subnet_region = var.region
     },
@@ -38,7 +38,7 @@ module "network_prod" {
 
   subnets = [
     {
-      subnet_name   = "plural-prod-subnet"
+      subnet_name = format("%s-plural-prod", var.cluster_name)
       subnet_ip     = var.subnet_cidr
       subnet_region = var.region
     },

--- a/terraform/core-infra/gcp/variables.tf
+++ b/terraform/core-infra/gcp/variables.tf
@@ -1,3 +1,7 @@
+variable "project_id" {
+  type = string
+}
+
 variable "region" {
   type = string
   default = "us-east-2"

--- a/terraform/core-infra/gcp/variables.tf
+++ b/terraform/core-infra/gcp/variables.tf
@@ -3,37 +3,37 @@ variable "project" {
 }
 
 variable "region" {
-  type = string
+  type    = string
   default = "us-east-2"
 }
 
 variable "cluster_name" {
-    type = string
+  type = string
 }
 
 variable "subnet_cidr" {
-  type = string
+  type    = string
   default = "10.0.16.0/20"
 }
 
 variable "pods_cidr" {
-  type = string
+  type    = string
   default = "10.16.0.0/12"
 }
 
 variable "services_cidr" {
-  type = string
+  type    = string
   default = "10.1.0.0/20"
 }
 
 variable "ip_range_pods_name" {
-  type = string
+  type        = string
   description = "The secondary ip range to use for pods"
   default     = "ip-range-pods"
 }
 
 variable "ip_range_services_name" {
-  type = string
+  type        = string
   description = "The secondary ip range to use for services"
   default     = "ip-range-svc"
 }

--- a/terraform/core-infra/gcp/variables.tf
+++ b/terraform/core-infra/gcp/variables.tf
@@ -1,4 +1,4 @@
-variable "project_id" {
+variable "project" {
   type = string
 }
 

--- a/terraform/core-infra/gcp/variables.tf
+++ b/terraform/core-infra/gcp/variables.tf
@@ -29,11 +29,11 @@ variable "services_cidr" {
 variable "ip_range_pods_name" {
   type        = string
   description = "The secondary ip range to use for pods"
-  default     = "ip-range-pods"
+  default     = "plural-pods"
 }
 
 variable "ip_range_services_name" {
   type        = string
   description = "The secondary ip range to use for services"
-  default     = "ip-range-svc"
+  default     = "plural-services"
 }

--- a/terraform/core-infra/gcp/versions.tf
+++ b/terraform/core-infra/gcp/versions.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 provider "google" {
-  project = var.project_id
+  project = var.project
   region = var.region
 }
 

--- a/terraform/core-infra/gcp/versions.tf
+++ b/terraform/core-infra/gcp/versions.tf
@@ -3,10 +3,10 @@ terraform {
 
   required_providers {
     google = {
-      source  = "hashicorp/google"
+      source = "hashicorp/google"
     }
     plural = {
-      source = "pluralsh/plural"
+      source  = "pluralsh/plural"
       version = ">= 0.2.9"
     }
   }
@@ -14,9 +14,9 @@ terraform {
 
 provider "google" {
   project = var.project
-  region = var.region
+  region  = var.region
 }
 
 data "google_client_config" "default" {}
 
-provider "plural" { }
+provider "plural" {}

--- a/terraform/core-infra/gcp/versions.tf
+++ b/terraform/core-infra/gcp/versions.tf
@@ -13,6 +13,7 @@ terraform {
 }
 
 provider "google" {
+  project = var.project_id
   region = var.region
 }
 


### PR DESCRIPTION
# GCP Configuration Improvements

## Key Changes

- **Standardized Default Names**: 
  - Updated default subnetwork name to `plural-core` across configurations
  - Standardized IP range names to `plural-pods` and `plural-services`

- **Dynamic Resource Naming**:
  - Implemented dynamic generation of network and subnetwork names based on cluster name
  - Added `subnetwork_name` local variable for consistent naming pattern
  - Network names now follow format: `${cluster_name}-${network_name}`

- **Bug Fixes**:
  - Fixed network/subnetwork reference paths in core infrastructure stack
  - Corrected CIDR range reference typo
  - Resolved variable naming conflicts

- **Dependencies Update**:
  - Updated console chart version to 0.3.84
  - Upgraded PostgreSQL module to version 25.2

![image](https://github.com/user-attachments/assets/4ff07ef8-f52d-4183-a8e7-7f9fcf06da26)