### PR TITLE
fix(terraform): fix gcp provisioning when using plural up

### DIFF
--- a/terraform/clouds/gcp/network.tf
+++ b/terraform/clouds/gcp/network.tf
@@ -14,7 +14,7 @@ module "gcp-network" {
   ]
 
   secondary_ranges = {
-    (var.subnetwork) = [
+    (local.subnetwork_name) = [
       {
         range_name    = var.ip_range_pods_name
         ip_cidr_range = var.pods_cidr


### PR DESCRIPTION
This fixes an issue during `plural up` where it could not find correct subnetwork range.

Tested with full `plural up` from scratch.