### PR TITLE
feat(terraform): add project_id variable to GCP context module configuration

### DIFF
--- a/terraform/core-infra/gcp/context.tf
+++ b/terraform/core-infra/gcp/context.tf
@@ -24,5 +24,6 @@ resource "plural_service_context" "mgmt" {
     network      = data.google_container_cluster.mgmt.network
     subnetwork   = data.google_container_cluster.mgmt.subnetwork
     cidr         = data.google_compute_subnetwork.subnetwork.ip_cidr_range
+    project_id   = var.project
   })
 }


### PR DESCRIPTION
This will be needed for the postgres scaffolds catalog app.