### PR TITLE
feat(insights): v1.0.0 - Enable upgrade insights on EKS clusters by default

### DIFF
--- a/resources/upgradeinsights/eks/insights.yaml.liquid
+++ b/resources/upgradeinsights/eks/insights.yaml.liquid
@@ -1,0 +1,8 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: UpgradeInsights
+metadata:
+  name: this
+spec:
+  distro: EKS
+  clusterName: {{ cluster.name }}
+  interval: 5m

--- a/setup/globalservices/eks-insights.yaml
+++ b/setup/globalservices/eks-insights.yaml
@@ -1,0 +1,18 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: GlobalService
+metadata:
+  name: upgrade-insights
+  namespace: infra
+spec:
+  distro: EKS
+  template:
+    name: upgrade-insights
+    namespace: plrl-deploy-operator
+    git:
+      ref: main
+      folder: resources/upgradeinsights/eks
+    repositoryRef:
+      kind: GitRepository
+      name: infra
+      namespace: infra
+    


### PR DESCRIPTION
## Changes

This PR adds default upgrade insights configuration for EKS clusters in Plural.

### New Files
- `resources/upgradeinsights/eks/insights.yaml.liquid`: Template for upgrade insights configuration with default 5-minute interval
- `setup/globalservices/eks-insights.yaml`: GlobalService definition that applies the upgrade insights configuration to all EKS clusters

### Purpose
This enhancement provides automatic upgrade insights for EKS clusters, improving observability and making it easier for users to track available upgrades and plan maintenance activities.

### Related
- PROD-3586 - Enable upgrade insights on EKS clusters by default in Plural