### PR TITLE
feat: enable eks pod identity on clusters by default

### DIFF
--- a/templates/setup/console.tf
+++ b/templates/setup/console.tf
@@ -28,7 +28,7 @@ resource "helm_release" "certmanager" {
   namespace        = "cert-manager"
   chart            = "cert-manager"
   repository       = "https://charts.jetstack.io"
-  version          = "v1.13.6"
+  version          = "v1.17.2"
   create_namespace = true
   timeout          = 300
   wait             = true
@@ -44,7 +44,7 @@ resource "helm_release" "flux" {
   namespace        = "flux"
   chart            = "flux2"
   repository       = "https://fluxcd-community.github.io/helm-charts"
-  version          = "2.12.4"
+  version          = "2.15.0"
   create_namespace = true
   timeout          = 300
   wait             = false
@@ -60,7 +60,7 @@ resource "helm_release" "runtime" {
   namespace        = "plural-runtime"
   chart            = "runtime"
   repository       = "https://pluralsh.github.io/bootstrap"
-  version          = "0.1.26"
+  version          = "0.1.30"
   create_namespace = true
   timeout          = 300
   wait             = false
@@ -76,7 +76,7 @@ resource "helm_release" "console" {
   namespace        = "plrl-console"
   chart            = "console"
   repository       = "https://pluralsh.github.io/console"
-  version          = "0.3.84"
+  version          = "0.3.95"
   create_namespace = true
   timeout          = 600
   wait             = true

--- a/terraform/clouds/aws/iam.tf
+++ b/terraform/clouds/aws/iam.tf
@@ -1,21 +1,4 @@
 // Permissions for the stacks
-resource "aws_iam_role" "stacks_role" {
-  name = "${var.cluster_name}-plrl-stacks"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "pods.eks.amazonaws.com"
-        }
-      }
-    ]
-  })
-}
-
 resource "aws_iam_policy" "stacks" {
   name_prefix = "stacks"
   description = "stacks permissions for ${var.cluster_name}"
@@ -31,6 +14,27 @@ resource "aws_iam_policy" "stacks" {
       ]
     }
   POLICY
+}
+
+resource "aws_iam_role" "stacks_role" {
+  name = "${var.cluster_name}-plrl-stacks"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEksAuthToAssumeRoleForPodIdentity"
+        Effect = "Allow"
+        Principal = {
+          Service = "pods.eks.amazonaws.com"
+        }
+        Action = [
+          "sts:AssumeRole",
+          "sts:TagSession"
+        ]
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "stacks_policy_attach" {
@@ -53,11 +57,15 @@ resource "aws_iam_role" "eks_insights_role" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action = "sts:AssumeRole"
+        Sid    = "AllowEksAuthToAssumeRoleForPodIdentity"
         Effect = "Allow"
         Principal = {
           Service = "pods.eks.amazonaws.com"
         }
+        Action = [
+          "sts:AssumeRole",
+          "sts:TagSession"
+        ]
       }
     ]
   })
@@ -105,11 +113,15 @@ resource "aws_iam_role" "cloudwatch_exporter_role" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action = "sts:AssumeRole"
+        Sid    = "AllowEksAuthToAssumeRoleForPodIdentity"
         Effect = "Allow"
         Principal = {
           Service = "pods.eks.amazonaws.com"
         }
+        Action = [
+          "sts:AssumeRole",
+          "sts:TagSession"
+        ]
       }
     ]
   })

--- a/terraform/clouds/aws/iam.tf
+++ b/terraform/clouds/aws/iam.tf
@@ -1,13 +1,19 @@
-module "assumable_role_stacks" {
-  source           = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version          = "5.39.1"
-  create_role      = true
-  role_name        = "${var.cluster_name}-plrl-stacks"
-  provider_url     = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
-  role_policy_arns = [aws_iam_policy.stacks.arn]
-  oidc_fully_qualified_subjects = [
-    "system:serviceaccount:plrl-deploy-operator:stacks",
-  ]
+// Permissions for the stacks
+resource "aws_iam_role" "stacks_role" {
+  name = "${var.cluster_name}-plrl-stacks"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "pods.eks.amazonaws.com"
+        }
+      }
+    ]
+  })
 }
 
 resource "aws_iam_policy" "stacks" {
@@ -27,10 +33,34 @@ resource "aws_iam_policy" "stacks" {
   POLICY
 }
 
-resource "aws_iam_role_policy_attachment" "eks_upgrade_insights" {
-  for_each   = module.eks.eks_managed_node_groups
-  role       = each.value.iam_role_name
-  policy_arn = aws_iam_policy.eks_upgrade_insights.arn
+resource "aws_iam_role_policy_attachment" "stacks_policy_attach" {
+  role       = aws_iam_role.stacks_role.name
+  policy_arn = aws_iam_policy.stacks.arn
+}
+
+resource "aws_eks_pod_identity_association" "stacks_pod_identity" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "plrl-deploy-operator"
+  service_account = "stacks"
+  role_arn        = aws_iam_role.stacks_role.arn
+}
+
+// Permissions for the upgrade insights
+resource "aws_iam_role" "eks_insights_role" {
+  name = "${var.cluster_name}-plrl-insights"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "pods.eks.amazonaws.com"
+        }
+      }
+    ]
+  })
 }
 
 resource "aws_iam_policy" "eks_upgrade_insights" {
@@ -55,16 +85,34 @@ resource "aws_iam_policy" "eks_upgrade_insights" {
   POLICY
 }
 
-module "assumable_role_cloudwatch_exporter" {
-  source           = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version          = "5.39.1"
-  create_role      = true
-  role_name        = "${var.cluster_name}-cloudwatch-exporter"
-  provider_url     = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
-  role_policy_arns = [aws_iam_policy.cloudwatch.arn]
-  oidc_subjects_with_wildcards = [
-    "system:serviceaccount:monitoring:cloudwatch-exporter*",
-  ]
+resource "aws_iam_role_policy_attachment" "eks_upgrade_insights" {
+  role       = aws_iam_role.eks_insights_role.name
+  policy_arn = aws_iam_policy.eks_upgrade_insights.arn
+}
+
+resource "aws_eks_pod_identity_association" "eks_insights_pod_identity" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "plrl-deploy-operator"
+  service_account = "deployment-operator"
+  role_arn        = aws_iam_role.eks_insights_role.arn
+}
+
+// Permissions for the cloudwatch exporter
+resource "aws_iam_role" "cloudwatch_exporter_role" {
+  name = "${var.cluster_name}-cloudwatch-exporter"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "pods.eks.amazonaws.com"
+        }
+      }
+    ]
+  })
 }
 
 resource "aws_iam_policy" "cloudwatch" {
@@ -98,4 +146,16 @@ resource "aws_iam_policy" "cloudwatch" {
       ]
     }
   POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_policy_attach" {
+  role       = aws_iam_role.cloudwatch_exporter_role.name
+  policy_arn = aws_iam_policy.cloudwatch.arn
+}
+
+resource "aws_eks_pod_identity_association" "cloudwatch_pod_identity" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "monitoring"
+  service_account = "cloudwatch-exporter"
+  role_arn        = aws_iam_role.cloudwatch_exporter_role.arn
 }

--- a/terraform/clouds/aws/outputs.tf
+++ b/terraform/clouds/aws/outputs.tf
@@ -10,9 +10,9 @@ output "cluster_arn" {
 output "cluster" {
   description = "thin object representing the clusters info"
   value = {
-    cluster_arn = module.eks.cluster_arn
-    cluster_name = module.eks.cluster_name
-    cluster_endpoint = module.eks.cluster_endpoint
+    cluster_arn                        = module.eks.cluster_arn
+    cluster_name                       = module.eks.cluster_name
+    cluster_endpoint                   = module.eks.cluster_endpoint
     cluster_certificate_authority_data = module.eks.cluster_certificate_authority_data
   }
 }
@@ -217,27 +217,27 @@ output "self_managed_node_groups_autoscaling_group_names" {
 }
 
 output "vpc" {
-    value = module.vpc
+  value = module.vpc
 }
 
 output "db" {
-    value = module.db
-    sensitive = true
+  value     = module.db
+  sensitive = true
 }
 
 output "db_url" {
-    value = local.db_url
-    sensitive = true
+  value     = local.db_url
+  sensitive = true
 }
 
 output "ready" {
-    value = local.cluster_ready
+  value = local.cluster_ready
 }
 
 output "identity" {
-  value = module.assumable_role_stacks.iam_role_arn
+  value = aws_iam_role.stacks_role.arn
 }
 
 output "cloudwatch_iam_arn" {
-  value = module.assumable_role_cloudwatch_exporter.iam_role_arn
+  value = aws_iam_role.cloudwatch_exporter_role.arn
 }

--- a/terraform/clouds/aws/runtime.tf
+++ b/terraform/clouds/aws/runtime.tf
@@ -1,6 +1,6 @@
 module "eks_blueprints_addons" {
   source = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.12" #ensure to update this to the latest/desired version
+  version = "~> 1.21" #ensure to update this to the latest/desired version
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint
@@ -21,23 +21,30 @@ module "eks_blueprints_addons" {
       most_recent = true
     }
     vpc-cni = {
-      most_recent = true
+      most_recent              = true
       service_account_role_arn = module.vpc_cni_irsa_role.iam_role_arn
     }
     kube-proxy = {
       most_recent = true
     }
+    eks-pod-identity-agent = {
+      most_recent = true
+    }
   }
 
   # mostly need this module to install the lb controller here.
-  enable_aws_load_balancer_controller    = true
-  enable_cluster_autoscaler              = true
-  enable_metrics_server                  = true
+  enable_aws_load_balancer_controller = true
+  enable_cluster_autoscaler           = true
+  enable_metrics_server               = true
+
+  depends_on = [
+    module.eks,
+  ]
 }
 
 module "vpc_cni_irsa_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.55"
 
   role_name             = "${module.eks.cluster_name}-vpc-cni"
   attach_vpc_cni_policy = true
@@ -46,22 +53,22 @@ module "vpc_cni_irsa_role" {
 
   oidc_providers = {
     main = {
-      provider_arn               = module.eks.oidc_provider_arn
+      provider_arn = module.eks.oidc_provider_arn
       namespace_service_accounts = ["kube-system:aws-node"]
     }
   }
 }
 
 module "ebs_csi_irsa_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.55"
 
   role_name             = "${module.eks.cluster_name}-ebs-csi"
   attach_ebs_csi_policy = true
 
   oidc_providers = {
     main = {
-      provider_arn               = module.eks.oidc_provider_arn
+      provider_arn = module.eks.oidc_provider_arn
       namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
     }
   }

--- a/terraform/clouds/aws/variables.tf
+++ b/terraform/clouds/aws/variables.tf
@@ -25,7 +25,7 @@ variable "create_db" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.30"
+  default = "1.32"
 }
 
 variable "public" {

--- a/terraform/clouds/azure/variables.tf
+++ b/terraform/clouds/azure/variables.tf
@@ -15,7 +15,7 @@ variable "create_db" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.30.9"
+  default = "1.32"
 }
 
 variable "create_resource_group" {

--- a/terraform/clouds/gcp/variables.tf
+++ b/terraform/clouds/gcp/variables.tf
@@ -15,7 +15,7 @@ variable "deletion_protection" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.30"
+  default = "1.32"
 }
 
 variable "node_pools" {


### PR DESCRIPTION
- configure eks pod identity for stacks/insights/cloudwatch
- use AL2023 in favor of soon to be deprecated AL2
- bump tf module versions
- bump default k8s version to 1.32
- bump initial console/runtime/helm/flux versions