### PR TITLE
Ensure secrets match env var conventions

### DIFF
--- a/charts/stateless/Chart.yaml
+++ b/charts/stateless/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stateless
 description: A Helm chart to deploy a basic stateless application
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.16.0"

--- a/charts/stateless/templates/secret.yaml
+++ b/charts/stateless/templates/secret.yaml
@@ -9,6 +9,8 @@ stringData:
   APP_VERSION: "{{ .Chart.AppVersion }}"
 {{ if .Values.secrets}}
 {{ range $key, $value := .Values.secrets }}
+{{ if mustRegexMatch "^[A-Z0-9]+(_[A-Za-z0-9_]+)*$" $key }}
   {{ $key }}: {{ $value | quote }}
+{{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
some of the flow setups are currently going to use service configuration that are not meant to be env vars, so this will help filter those out