### PR TITLE
fix(eks): add dependency on VPC NAT gateways for EKS cluster creation

### DIFF
--- a/terraform/clouds/aws/eks.tf
+++ b/terraform/clouds/aws/eks.tf
@@ -58,4 +58,6 @@ module "eks" {
   eks_managed_node_groups = var.managed_node_groups
 
   create_cloudwatch_log_group = var.create_cloudwatch_log_group
+
+  depends_on = [ module.vpc.nat_ids ] # This ensures that the VPC NAT gateways are created before the EKS cluster
 }


### PR DESCRIPTION
Tiny change to ensure that EKS creation will wait for the NAT gateway to finish creation first. I have occasionally encountered an issue where node groups were being created without NAT gateways. It turned at that NAT gateways failed to create due to resource limit on AWS account. With this change it was correctly waiting and failing on NAT gateway creation.