### PR TITLE
fix: Use managed zone name from project context

### DIFF
--- a/terraform/core-infra/gcp/dns.tf
+++ b/terraform/core-infra/gcp/dns.tf
@@ -1,5 +1,5 @@
 data "google_dns_managed_zone" "prod" {
-  name    = "{{ replace .AppDomain \".\" \"-\" }}"
+  name    = "{{ .Context.ManagedZone }}"
   project = "{{ .Project }}"
 }
 


### PR DESCRIPTION
Uses context entry added in https://github.com/pluralsh/plural-cli/pull/649.

Tested with CLI built from above branch and then:
```
plural up --service-account ... --git-ref marcin/prod-3763-gcp-appdomain-inference-is-goofy
```

Command completed successfully. Console was accessible. core-infra stack completed after approval.