### PR TITLE
Bugfix: Pass network_name to azure

### DIFF
--- a/setup/stacks/core-infra.yaml
+++ b/setup/stacks/core-infra.yaml
@@ -21,6 +21,7 @@ spec:
     cluster_name: [[ .Cluster ]]
   [[ if eq .Provider "azure" ]]
     resource_group_name: [[ .Project ]]
+    network_name: [[ .Cluster ]]-network
     subscription_id: [[ .Context.SubscriptionId ]]
     tenant_id: [[ .Context.TenantId ]]
     client_id:  {{ .StacksIdentity }}


### PR DESCRIPTION
fixes: https://linear.app/pluralsh/issue/PROD-4389/azure-plural-up-infers-wrong-network-name-for-mgmt-cluster-in-core

tested with `plural up --dry-run --git-ref pass-network-name-to-azure` 