### PR TITLE
Decouple azure dns zones in core infra

### DIFF
--- a/terraform/core-infra/azure/network.tf
+++ b/terraform/core-infra/azure/network.tf
@@ -2,14 +2,35 @@ data "azurerm_resource_group" "default" {
   name = var.resource_group_name
 }
 
-data "azurerm_private_dns_zone" "postgres" {
+resource "azurerm_private_dns_zone" "postgres" {
+  name                = "${var.cluster_name}.postgres.database.azure.com"
+  resource_group_name = data.azurerm_resource_group.default.name
+}
+
+resource "azurerm_private_dns_zone" "mysql" {
+  name                = "${var.cluster_name}.mysql.database.azure.com"
+  resource_group_name = data.azurerm_resource_group.default.name
+}
+
+data "azurerm_private_dns_zone" "postgres_mgmt" {
+  count = var.use_mgmt_dns_zone ? 1 : 0
+
   name                = var.postgres_dns_zone
   resource_group_name = data.azurerm_resource_group.default.name
 }
 
-data "azurerm_private_dns_zone" "mysql" {
+data "azurerm_private_dns_zone" "mysql_mgmt" {
+  count = var.use_mgmt_dns_zone ? 1 : 0
+
   name                = var.mysql_dns_zone
   resource_group_name = data.azurerm_resource_group.default.name
+}
+
+locals {
+  postgres_private_dns_zone_name = var.use_mgmt_dns_zone ? data.azurerm_private_dns_zone.postgres_mgmt[0].name : azurerm_private_dns_zone.postgres.name
+  postgres_private_dns_zone_id   = var.use_mgmt_dns_zone ? data.azurerm_private_dns_zone.postgres_mgmt[0].id : azurerm_private_dns_zone.postgres.id
+  mysql_private_dns_zone_name    = var.use_mgmt_dns_zone ? data.azurerm_private_dns_zone.mysql_mgmt[0].name : azurerm_private_dns_zone.mysql.name
+  mysql_private_dns_zone_id      = var.use_mgmt_dns_zone ? data.azurerm_private_dns_zone.mysql_mgmt[0].id : azurerm_private_dns_zone.mysql.id
 }
 
 data "azurerm_virtual_network" "plural" {
@@ -39,8 +60,8 @@ resource "plural_service_context" "plural" {
     sn_subnet_id   = data.azurerm_subnet.plural_sn.id
     pg_subnet_name = data.azurerm_subnet.plural_pg.name
     pg_subnet_id   = data.azurerm_subnet.plural_pg.id
-    dns_zone_name  = data.azurerm_private_dns_zone.postgres.name
-    dns_zone_id    = data.azurerm_private_dns_zone.postgres.id
+    dns_zone_name  = local.postgres_private_dns_zone_name
+    dns_zone_id    = local.postgres_private_dns_zone_id
   })
 }
 
@@ -98,14 +119,14 @@ resource "azurerm_subnet" "dev_mysql" {
 resource "azurerm_private_dns_zone_virtual_network_link" "dev_pg" {
   name                  = "dev.postgres.com"
   resource_group_name   = data.azurerm_resource_group.default.name
-  private_dns_zone_name = data.azurerm_private_dns_zone.postgres.name
+  private_dns_zone_name = local.postgres_private_dns_zone_name
   virtual_network_id    = azurerm_virtual_network.dev.id
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "dev_mysql" {
   name                  = "dev.mysql.com"
   resource_group_name   = data.azurerm_resource_group.default.name
-  private_dns_zone_name = data.azurerm_private_dns_zone.mysql.name
+  private_dns_zone_name = local.mysql_private_dns_zone_name
   virtual_network_id    = azurerm_virtual_network.dev.id
 }
 
@@ -119,19 +140,19 @@ resource "plural_service_context" "dev" {
     sn_subnet_id      = azurerm_subnet.dev_sn.id
     pg_subnet_name    = azurerm_subnet.dev_pg.name
     pg_subnet_id      = azurerm_subnet.dev_pg.id
-    pg_dns_zone_name  = data.azurerm_private_dns_zone.postgres.name
-    pg_dns_zone_id    = data.azurerm_private_dns_zone.postgres.id
+    pg_dns_zone_name  = local.postgres_private_dns_zone_name
+    pg_dns_zone_id    = local.postgres_private_dns_zone_id
     mysql_subnet_name = azurerm_subnet.dev_mysql.name
     mysql_subnet_id   = azurerm_subnet.dev_mysql.id
-    mysql_dns_zone_name  = data.azurerm_private_dns_zone.mysql.name
-    mysql_dns_zone_id    = data.azurerm_private_dns_zone.mysql.id
+    mysql_dns_zone_name  = local.mysql_private_dns_zone_name
+    mysql_dns_zone_id    = local.mysql_private_dns_zone_id
   {{ if .AppDomain }}
     ingress_dns_zone = "dev.{{ .AppDomain }}"
   {{ end}}
 
     # Kept for backwards compatibility. Use fields with pg_ prefix instead.
-    dns_zone_name  = data.azurerm_private_dns_zone.postgres.name
-    dns_zone_id    = data.azurerm_private_dns_zone.postgres.id
+    dns_zone_name  = local.postgres_private_dns_zone_name
+    dns_zone_id    = local.postgres_private_dns_zone_id
   })
 }
 
@@ -189,14 +210,14 @@ resource "azurerm_subnet" "prod_mysql" {
 resource "azurerm_private_dns_zone_virtual_network_link" "prod_pg" {
   name                  = "prod.postgres.com"
   resource_group_name   = data.azurerm_resource_group.default.name
-  private_dns_zone_name = data.azurerm_private_dns_zone.postgres.name
+  private_dns_zone_name = local.postgres_private_dns_zone_name
   virtual_network_id    = azurerm_virtual_network.prod.id
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "prod_mysql" {
   name                  = "prod.mysql.com"
   resource_group_name   = data.azurerm_resource_group.default.name
-  private_dns_zone_name = data.azurerm_private_dns_zone.mysql.name
+  private_dns_zone_name = local.mysql_private_dns_zone_name
   virtual_network_id    = azurerm_virtual_network.prod.id
 }
 
@@ -210,17 +231,17 @@ resource "plural_service_context" "prod" {
     sn_subnet_id      = azurerm_subnet.prod_sn.id
     pg_subnet_name    = azurerm_subnet.prod_pg.name
     pg_subnet_id      = azurerm_subnet.prod_pg.id
-    pg_dns_zone_name  = data.azurerm_private_dns_zone.postgres.name
-    pg_dns_zone_id    = data.azurerm_private_dns_zone.postgres.id
+    pg_dns_zone_name  = local.postgres_private_dns_zone_name
+    pg_dns_zone_id    = local.postgres_private_dns_zone_id
     mysql_subnet_name = azurerm_subnet.prod_mysql.name
     mysql_subnet_id   = azurerm_subnet.prod_mysql.id
-    mysql_dns_zone_name  = data.azurerm_private_dns_zone.mysql.name
-    mysql_dns_zone_id    = data.azurerm_private_dns_zone.mysql.id
+    mysql_dns_zone_name  = local.mysql_private_dns_zone_name
+    mysql_dns_zone_id    = local.mysql_private_dns_zone_id
     {{ if .AppDomain }}
     ingress_dns_zone = "{{ .AppDomain }}"
     {{ end}}
     # Kept for backwards compatibility. Use fields with pg_ prefix instead.
-    dns_zone_name  = data.azurerm_private_dns_zone.postgres.name
-    dns_zone_id    = data.azurerm_private_dns_zone.postgres.id
+    dns_zone_name  = local.postgres_private_dns_zone_name
+    dns_zone_id    = local.postgres_private_dns_zone_id
   })
 }

--- a/terraform/core-infra/azure/network.tf
+++ b/terraform/core-infra/azure/network.tf
@@ -13,24 +13,25 @@ resource "azurerm_private_dns_zone" "mysql" {
 }
 
 data "azurerm_private_dns_zone" "postgres_mgmt" {
-  count = var.use_mgmt_dns_zone ? 1 : 0
-
   name                = var.postgres_dns_zone
   resource_group_name = data.azurerm_resource_group.default.name
 }
 
 data "azurerm_private_dns_zone" "mysql_mgmt" {
-  count = var.use_mgmt_dns_zone ? 1 : 0
-
   name                = var.mysql_dns_zone
   resource_group_name = data.azurerm_resource_group.default.name
 }
 
 locals {
-  postgres_private_dns_zone_name = var.use_mgmt_dns_zone ? data.azurerm_private_dns_zone.postgres_mgmt[0].name : azurerm_private_dns_zone.postgres.name
-  postgres_private_dns_zone_id   = var.use_mgmt_dns_zone ? data.azurerm_private_dns_zone.postgres_mgmt[0].id : azurerm_private_dns_zone.postgres.id
-  mysql_private_dns_zone_name    = var.use_mgmt_dns_zone ? data.azurerm_private_dns_zone.mysql_mgmt[0].name : azurerm_private_dns_zone.mysql.name
-  mysql_private_dns_zone_id      = var.use_mgmt_dns_zone ? data.azurerm_private_dns_zone.mysql_mgmt[0].id : azurerm_private_dns_zone.mysql.id
+  mgmt_postgres_private_dns_zone_name = data.azurerm_private_dns_zone.postgres_mgmt.name
+  mgmt_postgres_private_dns_zone_id   = data.azurerm_private_dns_zone.postgres_mgmt.id
+  mgmt_mysql_private_dns_zone_name    = data.azurerm_private_dns_zone.mysql_mgmt.name
+  mgmt_mysql_private_dns_zone_id      = data.azurerm_private_dns_zone.mysql_mgmt.id
+
+  env_postgres_private_dns_zone_name = var.use_mgmt_dns_zone ? local.mgmt_postgres_private_dns_zone_name : azurerm_private_dns_zone.postgres.name
+  env_postgres_private_dns_zone_id   = var.use_mgmt_dns_zone ? local.mgmt_postgres_private_dns_zone_id : azurerm_private_dns_zone.postgres.id
+  env_mysql_private_dns_zone_name    = var.use_mgmt_dns_zone ? local.mgmt_mysql_private_dns_zone_name : azurerm_private_dns_zone.mysql.name
+  env_mysql_private_dns_zone_id      = var.use_mgmt_dns_zone ? local.mgmt_mysql_private_dns_zone_id : azurerm_private_dns_zone.mysql.id
 }
 
 data "azurerm_virtual_network" "plural" {
@@ -60,8 +61,8 @@ resource "plural_service_context" "plural" {
     sn_subnet_id   = data.azurerm_subnet.plural_sn.id
     pg_subnet_name = data.azurerm_subnet.plural_pg.name
     pg_subnet_id   = data.azurerm_subnet.plural_pg.id
-    dns_zone_name  = local.postgres_private_dns_zone_name
-    dns_zone_id    = local.postgres_private_dns_zone_id
+    dns_zone_name  = local.mgmt_postgres_private_dns_zone_name
+    dns_zone_id    = local.mgmt_postgres_private_dns_zone_id
   })
 }
 
@@ -119,14 +120,14 @@ resource "azurerm_subnet" "dev_mysql" {
 resource "azurerm_private_dns_zone_virtual_network_link" "dev_pg" {
   name                  = "dev.postgres.com"
   resource_group_name   = data.azurerm_resource_group.default.name
-  private_dns_zone_name = local.postgres_private_dns_zone_name
+  private_dns_zone_name = local.env_postgres_private_dns_zone_name
   virtual_network_id    = azurerm_virtual_network.dev.id
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "dev_mysql" {
   name                  = "dev.mysql.com"
   resource_group_name   = data.azurerm_resource_group.default.name
-  private_dns_zone_name = local.mysql_private_dns_zone_name
+  private_dns_zone_name = local.env_mysql_private_dns_zone_name
   virtual_network_id    = azurerm_virtual_network.dev.id
 }
 
@@ -140,19 +141,19 @@ resource "plural_service_context" "dev" {
     sn_subnet_id      = azurerm_subnet.dev_sn.id
     pg_subnet_name    = azurerm_subnet.dev_pg.name
     pg_subnet_id      = azurerm_subnet.dev_pg.id
-    pg_dns_zone_name  = local.postgres_private_dns_zone_name
-    pg_dns_zone_id    = local.postgres_private_dns_zone_id
+    pg_dns_zone_name  = local.env_postgres_private_dns_zone_name
+    pg_dns_zone_id    = local.env_postgres_private_dns_zone_id
     mysql_subnet_name = azurerm_subnet.dev_mysql.name
     mysql_subnet_id   = azurerm_subnet.dev_mysql.id
-    mysql_dns_zone_name  = local.mysql_private_dns_zone_name
-    mysql_dns_zone_id    = local.mysql_private_dns_zone_id
+    mysql_dns_zone_name  = local.env_mysql_private_dns_zone_name
+    mysql_dns_zone_id    = local.env_mysql_private_dns_zone_id
   {{ if .AppDomain }}
     ingress_dns_zone = "dev.{{ .AppDomain }}"
   {{ end}}
 
     # Kept for backwards compatibility. Use fields with pg_ prefix instead.
-    dns_zone_name  = local.postgres_private_dns_zone_name
-    dns_zone_id    = local.postgres_private_dns_zone_id
+    dns_zone_name  = local.env_postgres_private_dns_zone_name
+    dns_zone_id    = local.env_postgres_private_dns_zone_id
   })
 }
 
@@ -210,14 +211,14 @@ resource "azurerm_subnet" "prod_mysql" {
 resource "azurerm_private_dns_zone_virtual_network_link" "prod_pg" {
   name                  = "prod.postgres.com"
   resource_group_name   = data.azurerm_resource_group.default.name
-  private_dns_zone_name = local.postgres_private_dns_zone_name
+  private_dns_zone_name = local.env_postgres_private_dns_zone_name
   virtual_network_id    = azurerm_virtual_network.prod.id
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "prod_mysql" {
   name                  = "prod.mysql.com"
   resource_group_name   = data.azurerm_resource_group.default.name
-  private_dns_zone_name = local.mysql_private_dns_zone_name
+  private_dns_zone_name = local.env_mysql_private_dns_zone_name
   virtual_network_id    = azurerm_virtual_network.prod.id
 }
 
@@ -231,17 +232,17 @@ resource "plural_service_context" "prod" {
     sn_subnet_id      = azurerm_subnet.prod_sn.id
     pg_subnet_name    = azurerm_subnet.prod_pg.name
     pg_subnet_id      = azurerm_subnet.prod_pg.id
-    pg_dns_zone_name  = local.postgres_private_dns_zone_name
-    pg_dns_zone_id    = local.postgres_private_dns_zone_id
+    pg_dns_zone_name  = local.env_postgres_private_dns_zone_name
+    pg_dns_zone_id    = local.env_postgres_private_dns_zone_id
     mysql_subnet_name = azurerm_subnet.prod_mysql.name
     mysql_subnet_id   = azurerm_subnet.prod_mysql.id
-    mysql_dns_zone_name  = local.mysql_private_dns_zone_name
-    mysql_dns_zone_id    = local.mysql_private_dns_zone_id
+    mysql_dns_zone_name  = local.env_mysql_private_dns_zone_name
+    mysql_dns_zone_id    = local.env_mysql_private_dns_zone_id
     {{ if .AppDomain }}
     ingress_dns_zone = "{{ .AppDomain }}"
     {{ end}}
     # Kept for backwards compatibility. Use fields with pg_ prefix instead.
-    dns_zone_name  = local.postgres_private_dns_zone_name
-    dns_zone_id    = local.postgres_private_dns_zone_id
+    dns_zone_name  = local.env_postgres_private_dns_zone_name
+    dns_zone_id    = local.env_postgres_private_dns_zone_id
   })
 }

--- a/terraform/core-infra/azure/variables.tf
+++ b/terraform/core-infra/azure/variables.tf
@@ -30,7 +30,7 @@ variable "client_id" {
 
 variable "use_mgmt_dns_zone" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "postgres_dns_zone" {

--- a/terraform/core-infra/azure/variables.tf
+++ b/terraform/core-infra/azure/variables.tf
@@ -7,12 +7,12 @@ variable "resource_group_name" {
 }
 
 variable "network_name" {
-  type = string
+  type    = string
   default = "plural"
 }
 
 variable "region" {
-  type = string
+  type    = string
   default = "us-east-2"
 }
 
@@ -28,6 +28,11 @@ variable "client_id" {
   type = string
 }
 
+variable "use_mgmt_dns_zone" {
+  type    = bool
+  default = false
+}
+
 variable "postgres_dns_zone" {
   default = "plrl.postgres.database.azure.com"
 }
@@ -37,21 +42,21 @@ variable "mysql_dns_zone" {
 }
 
 variable "network_cidrs" {
-  type = list(string)
+  type    = list(string)
   default = ["10.52.0.0/16"]
 }
 
 variable "subnet_cidrs" {
-  type = list(string)
+  type    = list(string)
   default = ["10.52.0.0/20"]
 }
 
 variable "postgres_cidrs" {
-  type = list(string)
+  type    = list(string)
   default = ["10.52.16.0/24"]
 }
 
 variable "mysql_cidrs" {
-  type = list(string)
+  type    = list(string)
   default = ["10.52.17.0/24"]
 }

--- a/terraform/core-infra/azure/variables.tf
+++ b/terraform/core-infra/azure/variables.tf
@@ -30,7 +30,7 @@ variable "client_id" {
 
 variable "use_mgmt_dns_zone" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "postgres_dns_zone" {


### PR DESCRIPTION
The core-infra stack was reusing the dev/prod db dns zones created on the mgmt cluster. This PR creates a new set and optionally reads from the mgmt cluster if the `use_mgmt_dns_zone` var on core-infra is `true`; defaults to `false`