### PR TITLE
fix: bump default k8s version across providers and fix azure pg private dns zone name

### DIFF
--- a/terraform/clouds/aws/variables.tf
+++ b/terraform/clouds/aws/variables.tf
@@ -25,12 +25,12 @@ variable "create_db" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.32"
+  default = "1.34"
 }
 
 variable "next_kubernetes_version" {
   type    = string
-  default = "1.32"
+  default = "1.34"
 }
 
 

--- a/terraform/clouds/azure/postgres.tf
+++ b/terraform/clouds/azure/postgres.tf
@@ -31,7 +31,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "mysql" {
 resource "azurerm_private_dns_zone" "postgres" {
   count = var.create_db ? 1 : 0
 
-  name                = local.db_name
+  name                = var.postgres_dns_zone
   resource_group_name = local.resource_group.name
 }
 

--- a/terraform/clouds/azure/variables.tf
+++ b/terraform/clouds/azure/variables.tf
@@ -15,12 +15,12 @@ variable "create_db" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.32"
+  default = "1.34"
 }
 
 variable "next_kubernetes_version" {
   type    = string
-  default = "1.32"
+  default = "1.34"
 }
 
 variable "create_resource_group" {

--- a/terraform/clouds/gcp/variables.tf
+++ b/terraform/clouds/gcp/variables.tf
@@ -15,12 +15,12 @@ variable "deletion_protection" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.32"
+  default = "1.34"
 }
 
 variable "next_kubernetes_version" {
   type    = string
-  default = "1.32"
+  default = "1.34"
 }
 
 variable "node_pools" {

--- a/terraform/clouds/linode/variables.tf
+++ b/terraform/clouds/linode/variables.tf
@@ -30,7 +30,7 @@ variable "engine_id" {
 
 variable "kubernetes_vsn" {
   type = string
-  default = "1.27"
+  default = "1.34"
 }
 
 variable "node_pools" {

--- a/terraform/modules/clusters/aws/variables.tf
+++ b/terraform/modules/clusters/aws/variables.tf
@@ -23,7 +23,7 @@ variable "public" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.30"
+  default = "1.34"
 }
 
 variable "vpc_cidr" {

--- a/terraform/modules/clusters/azure/variables.tf
+++ b/terraform/modules/clusters/azure/variables.tf
@@ -13,7 +13,7 @@ variable "tier" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.30.9"
+  default = "1.34"
 }
 
 variable "resource_group_name" {

--- a/terraform/modules/clusters/gcp/variables.tf
+++ b/terraform/modules/clusters/gcp/variables.tf
@@ -19,7 +19,7 @@ variable "region" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.32"
+  default = "1.34"
 }
 
 variable "node_pools" {

--- a/terraform/modules/clusters/linode/variables.tf
+++ b/terraform/modules/clusters/linode/variables.tf
@@ -1,7 +1,7 @@
 
 variable "kubernetes_vsn" {
   type = string
-  default = "1.29"
+  default = "1.34"
 }
 
 variable "cluster" {


### PR DESCRIPTION
Most of the default k8s versions were outdated and in case of azure `plural up` was failing with outdated version. Additionally, I have fixed an issue where `azurerm_private_dns_zone` name was invalid as it requires valid domain name.